### PR TITLE
Fixes for clipping regions with multiple Y axes.  Also fixes inverted graphs with Axis.left specified.

### DIFF
--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -1378,37 +1378,7 @@ Axis.prototype = {
 		axis.bottom = chart.chartHeight - axis.height - axis.top;
 		axis.right = chart.chartWidth - axis.width - axis.left;
 		axis.len = mathMax(axis.horiz ? axis.width : axis.height, 0); // mathMax fixes #905
-		if (!axis.isXAxis) {
-			axis.clipBox = {
-				x: chart.plotBorderWidth / 2,
-				y: chart.plotBorderWidth / 2,
-				width: chart.inverted ? axis.height : axis.width,
-				height: chart.inverted ? axis.width : axis.height
-			};
-		}
 	},
-
-	/**
-	 * Check whether a given point is within the clip area for this axis
-	 *
-	 * @param {Number} plotX Pixel x relative to the plot area
-	 * @param {Number} plotY Pixel y relative to the plot area
-	 *
-	 * Note that we intentionally don't have an inverted parameter.
-	 * The clip is always oriented normally and the graph is rotated if inverted,
-	 * so the orientation of plotX, plotY is always correct
-	 */
-	isInsideClip: function (plotX, plotY) {
-		var result = true,
-			clipBox = this.clipBox;
-
-		if (clipBox) {
-			result =  plotX >= clipBox.x && plotX <= (clipBox.x + clipBox.width) &&
-				plotY >= clipBox.y && plotY <= (clipBox.y + clipBox.height);
-		}
-		return result;
-	},
-
 
 	/**
 	 * Get the actual axis extremes
@@ -1756,17 +1726,6 @@ Axis.prototype = {
 					axis.addPlotBandOrLine(plotLineOptions);
 				});
 				axis._addedPlotLB = true;
-			}
-
-			if (axis.clipBox) {
-				if (!axis.clipRect) {
-					axis.clipRect = renderer.clipRect(axis.clipBox);
-				} else {
-					axis.clipRect.animate({
-						width: axis.clipBox.width,
-						height: axis.clipBox.height
-					});
-				}
 			}
 
 		} // end if hasData

--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -1370,7 +1370,37 @@ Axis.prototype = {
 		axis.bottom = chart.chartHeight - axis.height - axis.top;
 		axis.right = chart.chartWidth - axis.width - axis.left;
 		axis.len = mathMax(axis.horiz ? axis.width : axis.height, 0); // mathMax fixes #905
+		if (!axis.isXAxis) {
+			axis.clipBox = {
+				x: chart.plotBorderWidth / 2,
+				y: chart.plotBorderWidth / 2,
+				width: chart.inverted ? axis.height : axis.width,
+				height: chart.inverted ? axis.width : axis.height
+			};
+		}
 	},
+
+	/**
+	 * Check whether a given point is within the clip area for this axis
+	 *
+	 * @param {Number} plotX Pixel x relative to the plot area
+	 * @param {Number} plotY Pixel y relative to the plot area
+	 *
+	 * Note that we intentionally don't have an inverted parameter.
+	 * The clip is always oriented normally and the graph is rotated if inverted,
+	 * so the orientation of plotX, plotY is always correct
+	 */
+	isInsideClip: function (plotX, plotY) {
+		var result = true,
+			clipBox = this.clipBox;
+
+		if (clipBox) {
+			result =  plotX >= clipBox.x && plotX <= (clipBox.x + clipBox.width) &&
+				plotY >= clipBox.y && plotY <= (clipBox.y + clipBox.height);
+		}
+		return result;
+	},
+
 
 	/**
 	 * Get the actual axis extremes
@@ -1718,6 +1748,17 @@ Axis.prototype = {
 					axis.addPlotBandOrLine(plotLineOptions);
 				});
 				axis._addedPlotLB = true;
+			}
+
+			if (axis.clipBox) {
+				if (!axis.clipRect) {
+					axis.clipRect = renderer.clipRect(axis.clipBox);
+				} else {
+					axis.clipRect.animate({
+						width: axis.clipBox.width,
+						height: axis.clipBox.height
+					});
+				}
 			}
 
 		} // end if hasData

--- a/js/parts/MouseTracker.js
+++ b/js/parts/MouseTracker.js
@@ -109,10 +109,15 @@ MouseTracker.prototype = {
 	 * the plot area.
 	 */
 	getIndex: function (e) {
-		var chart = this.chart;
+		var chart = this.chart,
+			hoverSeries = chart.hoverSeries,
+			left = hoverSeries ? hoverSeries.xAxis.left : chart.plotLeft,
+			bottom = hoverSeries ? hoverSeries.xAxis.top + hoverSeries.xAxis.height : chart.plotTop + chart.plotHeight;
+			//bottom =
 		return chart.inverted ? 
-			chart.plotHeight + chart.plotTop - e.chartY : 
-			e.chartX - chart.plotLeft;
+			//chart.plotHeight + chart.plotTop - e.chartY :
+			bottom - e.chartY :
+			e.chartX - left;
 	},
 
 	/**
@@ -143,9 +148,12 @@ MouseTracker.prototype = {
 						series[j].options.enableMouseTracking !== false &&
 						!series[j].noSharedTooltip && series[j].tooltipPoints.length) {
 					point = series[j].tooltipPoints[index];
-					point._dist = mathAbs(index - point[series[j].xAxis.tooltipPosName || 'plotX']);
-					distance = mathMin(distance, point._dist);
-					points.push(point);
+					//toddo -adjust for group offset
+					if (series[j].isInsideClip(point.plotX, point.plotY)) {
+						point._dist = mathAbs(index - point[series[j].xAxis.tooltipPosName || 'plotX']);
+						distance = mathMin(distance, point._dist);
+						points.push(point);
+					}
 				}
 			}
 			// remove furthest points
@@ -164,12 +172,11 @@ MouseTracker.prototype = {
 
 		// separate tooltip and general mouse events
 		if (hoverSeries && hoverSeries.tracker) { // only use for line-type series with common tracker
-
 			// get the point
 			point = hoverSeries.tooltipPoints[index];
 
 			// a new point is hovered, refresh the tooltip
-			if (point && point !== hoverPoint) {
+			if (point && point !== hoverPoint && hoverSeries.isInsideClip(point.plotX, point.plotY)) {
 
 				// trigger the events
 				point.onMouseOver();

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -1430,15 +1430,17 @@ Series.prototype = {
 			clipRect,
 			markerClipRect,
 			animation = series.options.animation,
-			clipBox = chart.clipBox,
+			clipBox = series.clipBox,
 			inverted = chart.inverted,
-			sharedClipKey;
+			sharedClipKey,
+			sharedClipBox = extend(null, clipBox);
 
 		// Animation option is set to true
 		if (animation && !isObject(animation)) {
 			animation = defaultPlotOptions[series.type].animation;
 		}
-		sharedClipKey = '_sharedClip' + animation.duration + animation.easing;
+		sharedClipKey = '_sharedClip' + animation.duration + animation.easing +
+			clipBox.x + '-' + clipBox.y + '-' + clipBox.width + '-' + clipBox.height;
 
 		// Initialize the animation. Set up the clipping rectangle.
 		if (init) { 
@@ -1448,7 +1450,7 @@ Series.prototype = {
 			markerClipRect = chart[sharedClipKey + 'm'];
 			if (!clipRect) {
 				chart[sharedClipKey] = clipRect = renderer.clipRect(
-					extend(clipBox, { width: 0 })
+					extend(sharedClipBox, { width: 0 })
 				);
 				
 				chart[sharedClipKey + 'm'] = markerClipRect = renderer.clipRect(
@@ -1490,17 +1492,16 @@ Series.prototype = {
 	 */
 	afterAnimate: function () {
 		var chart = this.chart,
+			series = this,
 			sharedClipKey = this.sharedClipKey,
-			group = this.group,
-			clipRect;
+			group = this.group;
 			
 		if (group && this.options.clip !== false) {
-			if (this.yAxis.clipRect) {
-				clipRect = this.yAxis.clipRect;
-			} else {
-				clipRect = chart.clipRect;
+			if (!series.clipRect) {
+				series.clipRect = chart.renderer.clipRect(series.clipBox);
 			}
-			group.clip(clipRect);
+
+			group.clip(series.clipRect);
 
 			this.markerGroup.clip(); // no clip
 		}
@@ -1512,6 +1513,27 @@ Series.prototype = {
 				chart[sharedClipKey + 'm'] = chart[sharedClipKey + 'm'].destroy();
 			}
 		}, 100);
+	},
+
+	/**
+	 * Check whether a given point is within the clip area for this series
+	 *
+	 * @param {Number} plotX Pixel x relative to the plot area
+	 * @param {Number} plotY Pixel y relative to the plot area
+	 *
+	 * Note that we intentionally don't have an inverted parameter.
+	 * The clip is always oriented normally and the graph is rotated if inverted,
+	 * so the orientation of plotX, plotY is always correct
+	 */
+	isInsideClip: function (plotX, plotY) {
+		var result = true,
+			clipBox = this.clipBox;
+
+		if (clipBox) {
+			result =  plotX >= clipBox.x && plotX <= (clipBox.x + clipBox.width) &&
+				plotY >= clipBox.y && plotY <= (clipBox.y + clipBox.height);
+		}
+		return result;
 	},
 
 	/**
@@ -1547,8 +1569,7 @@ Series.prototype = {
 				graphic = point.graphic;
 				pointMarkerOptions = point.marker || {};
 				enabled = (seriesMarkerOptions.enabled && pointMarkerOptions.enabled === UNDEFINED) || pointMarkerOptions.enabled;
-				isInside = series.yAxis.isInsideClip(plotX, plotY) &&
-							chart.isInsidePlot(plotX, plotY, chart.inverted);
+				isInside = series.isInsideClip(plotX, plotY);
 				
 				// only draw the point if y is defined
 				if (enabled && plotY !== UNDEFINED && !isNaN(plotY)) {
@@ -2161,8 +2182,7 @@ Series.prototype = {
 			visibility = series.visible ? VISIBLE : HIDDEN,
 			zIndex = options.zIndex,
 			hasRendered = series.hasRendered,
-			chartSeriesGroup = chart.seriesGroup,
-			clipRect;
+			chartSeriesGroup = chart.seriesGroup;
 		
 		// the group
 		group = series.plotGroup(
@@ -2180,7 +2200,10 @@ Series.prototype = {
 			zIndex, 
 			chartSeriesGroup
 		);
-		
+
+		// determine clipping region - must be defined before animiation init
+		series.clipBox = createClipBoxFromAxes(series.xAxis, series.yAxis);
+
 		// initiate the animation
 		if (doAnimation) {
 			series.animate(true);
@@ -2216,14 +2239,12 @@ Series.prototype = {
 		
 		// Initial clipping, must be defined after inverting groups for VML
 		if (options.clip !== false && !series.sharedClipKey && !hasRendered) {
-			if (series.yAxis.clipRect) {
-				clipRect = series.yAxis.clipRect;
-			} else {
-				clipRect = chart.clipRect;
+			if (!series.clipRect) {
+				series.clipRect = chart.renderer.clipRect(series.clipBox);
 			}
-			group.clip(clipRect);
+			group.clip(series.clipRect);
 			if (this.trackerGroup) {
-				this.trackerGroup.clip(clipRect);
+				this.trackerGroup.clip(series.clipRect);
 			}
 		}
 
@@ -2237,6 +2258,16 @@ Series.prototype = {
 		series.isDirty = series.isDirtyData = false; // means data is in accordance with what you see
 		// (See #322) series.isDirty = series.isDirtyData = false; // means data is in accordance with what you see
 		series.hasRendered = true;
+
+		// helper function
+		function createClipBoxFromAxes(xAxis, yAxis) {
+			return {
+				x: chart.plotBorderWidth / 2,
+				y: chart.plotBorderWidth / 2,
+				width: chart.inverted ? xAxis.height : xAxis.width,
+				height: chart.inverted ? yAxis.width : yAxis.height
+			};
+		}
 	},
 	
 	/**

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -1495,10 +1495,17 @@ Series.prototype = {
 	afterAnimate: function () {
 		var chart = this.chart,
 			sharedClipKey = this.sharedClipKey,
-			group = this.group;
+			group = this.group,
+			clipRect;
 			
 		if (group && this.options.clip !== false) {
-			group.clip(chart.clipRect);
+			if (this.yAxis.clipRect) {
+				clipRect = this.yAxis.clipRect;
+			} else {
+				clipRect = chart.clipRect;
+			}
+			group.clip(clipRect);
+
 			this.markerGroup.clip(); // no clip
 		}
 		
@@ -1544,7 +1551,8 @@ Series.prototype = {
 				graphic = point.graphic;
 				pointMarkerOptions = point.marker || {};
 				enabled = (seriesMarkerOptions.enabled && pointMarkerOptions.enabled === UNDEFINED) || pointMarkerOptions.enabled;
-				isInside = chart.isInsidePlot(plotX, plotY, chart.inverted);
+				isInside = series.yAxis.isInsideClip(plotX, plotY) &&
+							chart.isInsidePlot(plotX, plotY, chart.inverted);
 				
 				// only draw the point if y is defined
 				if (enabled && plotY !== UNDEFINED && !isNaN(plotY)) {
@@ -2136,8 +2144,8 @@ Series.prototype = {
 		}
 		// Place it on first and subsequent (redraw) calls
 		group.translate(
-			xAxis ? xAxis.left : chart.plotLeft, 
-			yAxis ? yAxis.top : chart.plotTop
+			chart.inverted ? (yAxis ? yAxis.left : chart.plotLeft) : (xAxis ? xAxis.left : chart.plotLeft),
+			chart.inverted ? (xAxis ? xAxis.top : chart.plotTop) : (yAxis ? yAxis.top : chart.plotTop)
 		);
 		
 		return group;
@@ -2157,7 +2165,8 @@ Series.prototype = {
 			visibility = series.visible ? VISIBLE : HIDDEN,
 			zIndex = options.zIndex,
 			hasRendered = series.hasRendered,
-			chartSeriesGroup = chart.seriesGroup;
+			chartSeriesGroup = chart.seriesGroup,
+			clipRect;
 		
 		// the group
 		group = series.plotGroup(
@@ -2211,9 +2220,14 @@ Series.prototype = {
 		
 		// Initial clipping, must be defined after inverting groups for VML
 		if (options.clip !== false && !series.sharedClipKey && !hasRendered) {
-			group.clip(chart.clipRect);
+			if (series.yAxis.clipRect) {
+				clipRect = series.yAxis.clipRect;
+			} else {
+				clipRect = chart.clipRect;
+			}
+			group.clip(clipRect);
 			if (this.trackerGroup) {
-				this.trackerGroup.clip(chart.clipRect);
+				this.trackerGroup.clip(clipRect);
 			}
 		}
 


### PR DESCRIPTION
Please see http://jsfiddle.net/sappling/UGK5d/ for a demonstration of the general problem with clipping and multiple y Axes.
See http://jsfiddle.net/sappling/aFPcp/ for demonstration of the problem with an inverted graph with multiple y Axes.  Note that the inverted version doesn't just have a clipping problem, it doesn't honor the Axis.left option either.
I believe that this fix handles both of these issues.

This may need some more work in one area.  I was not exactly clear of the purpose of the sharedClipKey during animation.  I have not done anything similar for these new clip regions.  If you can help me understand this, I'll be glad to try to update the per-axis clipping regions similarly if needed.
