### PR TITLE
Use 'crispEdges' option when drawing heatmaps to prevent the tiny gaps between cells.

### DIFF
--- a/js/modules/heatmap.src.js
+++ b/js/modules/heatmap.src.js
@@ -661,7 +661,8 @@ seriesTypes.heatmap = extendClass(seriesTypes.scatter, merge(colorSeriesMixin, {
 				x: Math.min(x1, x2),
 				y: Math.min(y1, y2),
 				width: Math.abs(x2 - x1),
-				height: Math.abs(y2 - y1)
+				height: Math.abs(y2 - y1),
+                                'shape-rendering': 'crispEdges',
 			};
 		});
 		


### PR DESCRIPTION
The artifact used to be very visible in Chrome and sometimes visible in Firefox
E.g.: http://www.highcharts.com/maps/demo/heatmap