### PR TITLE
removes dependency on http only for header font tags

### DIFF
--- a/js/themes/dark-unica.js
+++ b/js/themes/dark-unica.js
@@ -5,7 +5,7 @@
 
 // Load the fonts
 Highcharts.createElement('link', {
-	href: 'http://fonts.googleapis.com/css?family=Unica+One',
+	href: '//fonts.googleapis.com/css?family=Unica+One',
 	rel: 'stylesheet',
 	type: 'text/css'
 }, null, document.getElementsByTagName('head')[0]);

--- a/js/themes/grid-light.js
+++ b/js/themes/grid-light.js
@@ -5,7 +5,7 @@
 
 // Load the fonts
 Highcharts.createElement('link', {
-	href: 'http://fonts.googleapis.com/css?family=Dosis:400,600',
+	href: '//fonts.googleapis.com/css?family=Dosis:400,600',
 	rel: 'stylesheet',
 	type: 'text/css'
 }, null, document.getElementsByTagName('head')[0]);

--- a/js/themes/sand-signika.js
+++ b/js/themes/sand-signika.js
@@ -5,7 +5,7 @@
 
 // Load the fonts
 Highcharts.createElement('link', {
-	href: 'http://fonts.googleapis.com/css?family=Signika:400,700',
+	href: '//fonts.googleapis.com/css?family=Signika:400,700',
 	rel: 'stylesheet',
 	type: 'text/css'
 }, null, document.getElementsByTagName('head')[0]);


### PR DESCRIPTION
makes it so we don't get the annoying security warning when using themes with fonts on https pages :)