### PR TITLE
Option 'scrollbar.showButtons' (true by default) for ability hide left/right arrow buttons in scrollbar for a cleaner appearanc

### DIFF
--- a/js/highstock.src.js
+++ b/js/highstock.src.js
@@ -19732,6 +19732,7 @@ extend(defaultOptions, {
 		barBorderRadius: 0,
 		barBorderWidth: 1,
 		barBorderColor: '#bfc8d1',
+		showButtons: true,
 		buttonArrowColor: '#666',
 		buttonBackgroundColor: '#ebe7e8',
 		buttonBorderColor: '#bbb',
@@ -19943,7 +19944,11 @@ Scroller.prototype = {
 		);
 		scroller.navigatorWidth = navigatorWidth = pick(xAxis.len, chart.plotWidth - 2 * scrollbarHeight);
 		scroller.scrollerLeft = scrollerLeft = navigatorLeft - scrollbarHeight;
-		scroller.scrollerWidth = scrollerWidth = scrollerWidth = navigatorWidth + 2 * scrollbarHeight;
+		if (scrollbarOptions.showButtons) {
+			scroller.scrollerWidth = scrollerWidth = scrollerWidth = navigatorWidth + 2 * scrollbarHeight;
+		} else {
+			scroller.scrollerWidth = scrollerWidth = scrollerWidth = navigatorWidth;
+		}
 
 		// Set the scroller x axis extremes to reflect the total. The navigator extremes
 		// should always be the extremes of the union of all series in the chart as
@@ -20104,8 +20109,10 @@ Scroller.prototype = {
 		if (scrollbarEnabled && scrollbarGroup) {
 
 			// draw the buttons
-			scroller.drawScrollbarButton(0);
-			scroller.drawScrollbarButton(1);
+			if (scrollbarOptions.showButtons) {
+				scroller.drawScrollbarButton(0);
+				scroller.drawScrollbarButton(1);
+			}
 
 			scrollbarGroup[verb]({
 				translateX: scrollerLeft,
@@ -20116,8 +20123,12 @@ Scroller.prototype = {
 				width: scrollerWidth
 			});
 
-			// prevent the scrollbar from drawing to small (#1246)
-			scrX = scrollbarHeight + zoomedMin;
+			// prevent the scrollbar from drawing too small (#1246)
+			if (scrollbarOptions.showButtons) {
+				scrX = scrollbarHeight + zoomedMin;
+			} else {
+				scrX = zoomedMin;
+			}
 			scrWidth = range - scrollbarStrokeWidth;
 			if (scrWidth < scrollbarMinWidth) {
 				scrollbarPad = (scrollbarMinWidth - scrWidth) / 2;

--- a/js/highstock.src.js
+++ b/js/highstock.src.js
@@ -19804,7 +19804,7 @@ Scroller.prototype = {
 		if (!scroller.rendered) {
 			// the group
 			handles[index] = renderer.g('navigator-handle-' + ['left', 'right'][index])
-				.css({ cursor: 'e-resize' })
+				.css({ cursor: 'ew-resize' })
 				.attr({ zIndex: 4 - index }) // zIndex = 3 for right handle, 4 for left
 				.add();
 
@@ -19997,7 +19997,10 @@ Scroller.prototype = {
 					.attr({
 						fill: navigatorOptions.maskFill
 					}).add(navigatorGroup);
-				if (!navigatorOptions.maskInside) {
+				
+				if (navigatorOptions.maskInside) {
+					scroller.leftShade.css({ cursor: 'ew-resize '});
+				} else {
 					scroller.rightShade = renderer.rect()
 						.attr({
 							fill: navigatorOptions.maskFill
@@ -20215,8 +20218,6 @@ Scroller.prototype = {
 			top = scroller.top,
 			dragOffset,
 			hasDragged,
-			bodyStyle = document.body.style,
-			defaultBodyCursor,
 			baseSeries = scroller.baseSeries;
 
 		/**
@@ -20265,13 +20266,6 @@ Scroller.prototype = {
 				} else if (chartX > navigatorLeft + zoomedMin - scrollbarPad && chartX < navigatorLeft + zoomedMax + scrollbarPad) {
 					scroller.grabbedCenter = chartX;
 					scroller.fixedWidth = range;
-
-					// In SVG browsers, change the cursor. IE6 & 7 produce an error on changing the cursor,
-					// and IE8 isn't able to show it while dragging anyway.
-					if (chart.renderer.isSVG) {
-						defaultBodyCursor = bodyStyle.cursor;
-						bodyStyle.cursor = 'ew-resize';
-					}
 
 					dragOffset = chartX - zoomedMin;
 
@@ -20414,7 +20408,6 @@ Scroller.prototype = {
 			if (e.type !== 'mousemove') {
 				scroller.grabbedLeft = scroller.grabbedRight = scroller.grabbedCenter = scroller.fixedWidth =
 					scroller.fixedExtreme = scroller.otherHandlePos = hasDragged = dragOffset = null;
-				bodyStyle.cursor = defaultBodyCursor || '';
 			}
 
 		};

--- a/js/parts/Scroller.js
+++ b/js/parts/Scroller.js
@@ -172,7 +172,7 @@ Scroller.prototype = {
 		if (!scroller.rendered) {
 			// the group
 			handles[index] = renderer.g('navigator-handle-' + ['left', 'right'][index])
-				.css({ cursor: 'e-resize' })
+				.css({ cursor: 'ew-resize' })
 				.attr({ zIndex: 4 - index }) // zIndex = 3 for right handle, 4 for left
 				.add();
 
@@ -369,7 +369,10 @@ Scroller.prototype = {
 					.attr({
 						fill: navigatorOptions.maskFill
 					}).add(navigatorGroup);
-				if (!navigatorOptions.maskInside) {
+				
+				if (navigatorOptions.maskInside) {
+					scroller.leftShade.css({ cursor: 'ew-resize '});
+				} else {
 					scroller.rightShade = renderer.rect()
 						.attr({
 							fill: navigatorOptions.maskFill
@@ -593,8 +596,6 @@ Scroller.prototype = {
 			top = scroller.top,
 			dragOffset,
 			hasDragged,
-			bodyStyle = document.body.style,
-			defaultBodyCursor,
 			baseSeries = scroller.baseSeries;
 
 		/**
@@ -643,13 +644,6 @@ Scroller.prototype = {
 				} else if (chartX > navigatorLeft + zoomedMin - scrollbarPad && chartX < navigatorLeft + zoomedMax + scrollbarPad) {
 					scroller.grabbedCenter = chartX;
 					scroller.fixedWidth = range;
-
-					// In SVG browsers, change the cursor. IE6 & 7 produce an error on changing the cursor,
-					// and IE8 isn't able to show it while dragging anyway.
-					if (chart.renderer.isSVG) {
-						defaultBodyCursor = bodyStyle.cursor;
-						bodyStyle.cursor = 'ew-resize';
-					}
 
 					dragOffset = chartX - zoomedMin;
 
@@ -792,7 +786,6 @@ Scroller.prototype = {
 			if (e.type !== 'mousemove') {
 				scroller.grabbedLeft = scroller.grabbedRight = scroller.grabbedCenter = scroller.fixedWidth =
 					scroller.fixedExtreme = scroller.otherHandlePos = hasDragged = dragOffset = null;
-				bodyStyle.cursor = defaultBodyCursor || '';
 			}
 
 		};

--- a/js/parts/Scroller.js
+++ b/js/parts/Scroller.js
@@ -99,6 +99,7 @@ extend(defaultOptions, {
 		barBorderRadius: 0,
 		barBorderWidth: 1,
 		barBorderColor: '#bfc8d1',
+		showButtons: true,
 		buttonArrowColor: '#666',
 		buttonBackgroundColor: '#ebe7e8',
 		buttonBorderColor: '#bbb',
@@ -310,7 +311,11 @@ Scroller.prototype = {
 		);
 		scroller.navigatorWidth = navigatorWidth = pick(xAxis.len, chart.plotWidth - 2 * scrollbarHeight);
 		scroller.scrollerLeft = scrollerLeft = navigatorLeft - scrollbarHeight;
-		scroller.scrollerWidth = scrollerWidth = scrollerWidth = navigatorWidth + 2 * scrollbarHeight;
+		if (scrollbarOptions.showButtons) {
+			scroller.scrollerWidth = scrollerWidth = scrollerWidth = navigatorWidth + 2 * scrollbarHeight;
+		} else {
+			scroller.scrollerWidth = scrollerWidth = scrollerWidth = navigatorWidth;
+		}
 
 		// Set the scroller x axis extremes to reflect the total. The navigator extremes
 		// should always be the extremes of the union of all series in the chart as
@@ -468,8 +473,10 @@ Scroller.prototype = {
 		if (scrollbarEnabled && scrollbarGroup) {
 
 			// draw the buttons
-			scroller.drawScrollbarButton(0);
-			scroller.drawScrollbarButton(1);
+			if (scrollbarOptions.showButtons) {
+				scroller.drawScrollbarButton(0);
+				scroller.drawScrollbarButton(1);
+			}
 
 			scrollbarGroup[verb]({
 				translateX: scrollerLeft,
@@ -480,8 +487,12 @@ Scroller.prototype = {
 				width: scrollerWidth
 			});
 
-			// prevent the scrollbar from drawing to small (#1246)
-			scrX = scrollbarHeight + zoomedMin;
+			// prevent the scrollbar from drawing too small (#1246)
+			if (scrollbarOptions.showButtons) {
+				scrX = scrollbarHeight + zoomedMin;
+			} else {
+				scrX = zoomedMin;
+			}
 			scrWidth = range - scrollbarStrokeWidth;
 			if (scrWidth < scrollbarMinWidth) {
 				scrollbarPad = (scrollbarMinWidth - scrWidth) / 2;


### PR DESCRIPTION
I wanted it to look like this:

![screenshot 2015-01-26 16 03 45](https://cloud.githubusercontent.com/assets/97612/5910948/ee49ac3e-a574-11e4-8cef-dbbdeb5d3f3e.png)

