### PR TITLE
fix bug: tooltips not show after series.setData()

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -13335,6 +13335,8 @@ Series.prototype = {
 				}
 			}
 
+			delete series.kdTree;
+
 			// reset minRange (#878)
 			if (xAxis) {
 				xAxis.minRange = xAxis.userMinRange;

--- a/js/highmaps.src.js
+++ b/js/highmaps.src.js
@@ -12834,6 +12834,8 @@ Series.prototype = {
 				}
 			}
 
+			delete series.kdTree;
+
 			// reset minRange (#878)
 			if (xAxis) {
 				xAxis.minRange = xAxis.userMinRange;

--- a/js/highstock.src.js
+++ b/js/highstock.src.js
@@ -13335,6 +13335,8 @@ Series.prototype = {
 				}
 			}
 
+			delete series.kdTree;
+
 			// reset minRange (#878)
 			if (xAxis) {
 				xAxis.minRange = xAxis.userMinRange;

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -467,6 +467,8 @@ Series.prototype = {
 				}
 			}
 
+			delete series.kdTree;
+
 			// reset minRange (#878)
 			if (xAxis) {
 				xAxis.minRange = xAxis.userMinRange;


### PR DESCRIPTION
After setData() on a series, mouse over a series does not show tool tips and throws exception about tooltipOptions is undefined. The cause is that series points are cleared but kdTree having the references to those points are not cleared.

This fix simply clears series.kdTree after clearing old data points.