### PR TITLE
More accurate legend symbol placement for legends with large font sizes .and large symbol heights

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -11109,7 +11109,7 @@ var LegendSymbolMixin = Highcharts.LegendSymbolMixin = {
 		
 		item.legendSymbol = this.chart.renderer.rect(
 			0,
-			legend.baseline - 5 - (symbolHeight / 2),
+			legend.baseline - symbolHeight * 0.8 ,
 			legend.symbolWidth,
 			symbolHeight,
 			legend.options.symbolRadius || 0


### PR DESCRIPTION
Solves issue #3988

The previous legend symbol baseline calculation legend.baseline - 5 - (symbolHeight / 2) failed for large font sizes and large symbol heights.

The new calculation fits for small and large symbol sizes.

Should also be implemented for highstock and highmaps
