### PR TITLE
More accurate legend symbol placement for legends with large font sizes and large symbol heights V4

### DIFF
--- a/js/parts/Legend.js
+++ b/js/parts/Legend.js
@@ -707,10 +707,11 @@ var LegendSymbolMixin = Highcharts.LegendSymbolMixin = {
 	 */
 	drawRectangle: function (legend, item) {
 		var symbolHeight = legend.options.symbolHeight || 12;
+		var fontSize = this.chart.renderer.fontMetrics(legend.itemStyle.fontSize).f;
 		
 		item.legendSymbol = this.chart.renderer.rect(
 			0,
-			legend.baseline - 5 - (symbolHeight / 2),
+			legend.baseline - symbolHeight - (fontSize / 1.6 - symbolHeight) / 2,
 			legend.symbolWidth,
 			symbolHeight,
 			legend.options.symbolRadius || 0


### PR DESCRIPTION
Solves issue #3988

The previous legend symbol baseline calculation legend.baseline - 5 - (symbolHeight / 2) failed for large font sizes and large symbol heights.

The new calculation fits for small and large symbol sizes.