### PR TITLE
Fixed #3407, back button would disappear on map drilldown

### DIFF
--- a/js/highmaps.src.js
+++ b/js/highmaps.src.js
@@ -17364,16 +17364,16 @@ seriesTypes.map = extendClass(seriesTypes.scatter, merge(colorSeriesMixin, {
 			
 			// TODO: Animate this.group instead
 			each(this.points, function (point) {
-
-				point.graphic
-					.attr(level.shapeArgs)
-					.animate({
-						scaleX: 1,
-						scaleY: 1,
-						translateX: 0,
-						translateY: 0
-					}, animationOptions);
-
+				if (point.graphic) {
+					point.graphic
+						.attr(level.shapeArgs)
+						.animate({
+							scaleX: 1,
+							scaleY: 1,
+							translateX: 0,
+							translateY: 0
+						}, animationOptions);
+				}
 			});
 
 			this.animate = null;


### PR DESCRIPTION
When the user tried to drilldown to  aregion on the map, an null pointer exception would be thrown causing the back button to disappear. This small fix seems to fix the problem, but I couldn't run the tests, sorry!