### PR TITLE
Added repository information to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "4.0.3",
   "main": "js/highcharts.src.js",
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/highslide-software/highcharts.com.git"
+  },
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-jslint": "^1.1.12"


### PR DESCRIPTION
Can we get this merged to stop this warning from constantly showing up?

`npm WARN package.json Highcharts@4.0.3 No repository field.`
