### PR TITLE
Axis unsquish issue fix

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -7424,7 +7424,7 @@ Axis.prototype = {
 		}
 
 		// Prevent ticks from getting so close that we can't draw the labels
-		if (!this.tickAmount && this.len) { // Color axis with disabled legend has no length
+		if (!this.tickAmount && this.len && options.labels.enabled) { // Color axis with disabled legend has no length
 			axis.tickInterval = axis.unsquish();
 		}
 


### PR DESCRIPTION
When labels are disabled on one axis, we should not unsquish the axis. This gives a way of accurately control ticks when no labels exists.