### PR TITLE
Feature: Adding useHTML functionality to noData display

### DIFF
--- a/js/modules/no-data-to-display.src.js
+++ b/js/modules/no-data-to-display.src.js
@@ -35,7 +35,8 @@
 			fontWeight: 'bold',		
 			fontSize: '12px',
 			color: '#60606a'		
-		}
+		},
+        useHTML: false
 	};
 
 	/**
@@ -67,7 +68,7 @@
 			noDataOptions = options.noData;
 
 		if (!chart.noDataLabel) {
-			chart.noDataLabel = chart.renderer.label(text, 0, 0, null, null, null, null, null, 'no-data')
+			chart.noDataLabel = chart.renderer.label(text, 0, 0, null, null, null, noDataOptions.useHTML, null, 'no-data')
 				.attr(noDataOptions.attr)
 				.css(noDataOptions.style)
 				.add();


### PR DESCRIPTION
Sometimes, users may wish to add custom HTML to a noData label for tooltip functionality or just a customized label. This feature adds the 'useHTML' option to the noData chart option to allow for such customization.

```javascript
$('#container').highcharts({
        chart: {
            plotBackgroundColor: null,
            plotBorderWidth: null,
            plotShadow: false
        },
        lang:{
            noData: "Data is unavailable <i class='glyphicon glyphicon-info-sign' title=''></i>"
        },
        noData: {
            useHTML: true
        },
        title: {
            text: 'No data in pie chart'
        },
        series: [{
            type: 'pie',
            name: 'Random data',
            data: []
        }]
    });

chart = $('#container').highcharts();
```