### PR TITLE
Menu Item event.stopPropagation(); added

### DIFF
--- a/js/modules/exporting.src.js
+++ b/js/modules/exporting.src.js
@@ -111,6 +111,7 @@ defaultOptions.exporting = {
 				textKey: 'printChart',
 				onclick: function () {
 					this.print();
+					event.stopPropagation();
 				}
 			}, {
 				separator: true
@@ -118,6 +119,7 @@ defaultOptions.exporting = {
 				textKey: 'downloadPNG',
 				onclick: function () {
 					this.exportChart();
+					event.stopPropagation();
 				}
 			}, {
 				textKey: 'downloadJPEG',
@@ -125,6 +127,7 @@ defaultOptions.exporting = {
 					this.exportChart({
 						type: 'image/jpeg'
 					});
+					event.stopPropagation();
 				}
 			}, {
 				textKey: 'downloadPDF',
@@ -132,6 +135,7 @@ defaultOptions.exporting = {
 					this.exportChart({
 						type: 'application/pdf'
 					});
+					event.stopPropagation();
 				}
 			}, {
 				textKey: 'downloadSVG',
@@ -139,6 +143,7 @@ defaultOptions.exporting = {
 					this.exportChart({
 						type: 'image/svg+xml'
 					});
+					event.stopPropagation();
 				}
 			}
 			// Enable this block to add "View SVG" to the dropdown menu


### PR DESCRIPTION
When there is a chart click event and a menu item in export option is clicked, the chart event is fired.
To prevent it event.stopPropagation(); is added