### PR TITLE
Adds compatibility to drilldown with 'rounded-corners' plugin 

### DIFF
--- a/js/modules/drilldown.src.js
+++ b/js/modules/drilldown.src.js
@@ -172,7 +172,7 @@
 			seriesOptions: oldSeries.options,
 			levelSeriesOptions: levelSeriesOptions,
 			levelSeries: levelSeries,
-			shapeArgs: point.shapeArgs,
+			shapeArgs: point.dlBox || point.shapeArgs, // Adds compatibility for 'rounded-corners' plugin
 			bBox: point.graphic ? point.graphic.getBBox() : {}, // no graphic in line series with markers disabled
 			color: color,
 			lowerSeriesOptions: ddOptions,


### PR DESCRIPTION
Using Highcharts [rounded corners](https://github.com/highslide-software/rounded-corners) plugin and drilldown together, breaks after the third level.

[Issue demo](http://jsfiddle.net/davcs86/4wmf8p5u/2/)

after fix [demo](http://jsfiddle.net/davcs86/4wmf8p5u/3/)

