### PR TITLE
add %k in dateFormat

### DIFF
--- a/js/parts/Utilities.js
+++ b/js/parts/Utilities.js
@@ -333,6 +333,7 @@ dateFormat = function (format, timestamp, capitalize) {
 
 			// Time
 			'H': pad(hours), // Two digits hours in 24h format, 00 through 23
+			'k': hours, // Hours in 24h format, 0 through 23
 			'I': pad((hours % 12) || 12), // Two digits hours in 12h format, 00 through 11
 			'l': (hours % 12) || 12, // Hours in 12h format, 1 through 12
 			'M': pad(date[getMinutes]()), // Two digits minutes, 00 through 59

--- a/test/unit/UtilitiesTest.js
+++ b/test/unit/UtilitiesTest.js
@@ -319,6 +319,9 @@ UtilTest.prototype.testFormat = function () {
 UtilTest.prototype.testDateFormat = function () {
 	
 	// Issue #953
-	assertEquals('Two occurences of a pattern', '2012-01-01, 00:00 - 00:59', 
+	assertEquals('Two occurences of a pattern', '2012-01-01, 00:00 - 00:59',
 		dateFormat('%Y-%m-%d, %H:00 - %H:59', Date.UTC(2012, 0, 1, 0, 0, 0)));
+
+	assertEquals('Hours in 24 hours format', '5:55', dateFormat('%k:%M',
+		Date.UTC(2015, 0, 1, 5, 55, 0)));
 }


### PR DESCRIPTION
Very simple fix to add `%k` date format

The format is a subset of the formats for PHP's strftime function (mentioned [here](http://api.highcharts.com/highcharts#Highcharts))
And I think it's useful to add `%k`.