### PR TITLE
Fixed disappearing tooltips in zoom mode on some Android devices

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -10359,8 +10359,12 @@ extend(Highcharts.Pointer.prototype, {
 
 		// Don't initiate panning until the user has pinched. This prevents us from 
 		// blocking page scrolling as users scroll down a long page (#4210).
-		if (touchesLength > 1) {
+		if (touchesLength > 1
+		        || e.type === 'touchmove') {
 			self.initiated = true;
+		} else if (touchesLength === 1
+		        && e.type === 'touchstart') {
+		    self.initiated = undefined;
 		}
 
 		// On touch devices, only proceed to trigger click if a handler is defined


### PR DESCRIPTION
On some Android devices e.g. Sony Z3 there is a bug when you try to click on chart in zoom mode. See #3450. Go to http://jsfiddle.net/4vqr5rqv/ using Android device, zoom in the chart and try to click on some dots to show a tooltip.