### PR TITLE
Use throw new Error() for better browser compatibility

### DIFF
--- a/js/parts/Globals.js
+++ b/js/parts/Globals.js
@@ -95,7 +95,7 @@ var UNDEFINED,
 function error(code, stop) {
 	var msg = 'Highcharts error #' + code + ': www.highcharts.com/errors/' + code;
 	if (stop) {
-		throw msg;
+		throw new Error(msg);
 	}
 	// else ...
 	if (win.console) {


### PR DESCRIPTION
Just using throw 'string' isn't as reliable between browsers and that causes problems 
when using libraries like https://github.com/csnover/TraceKit

This change allows TraceKit to handle the error correctly in Firefox,
the same way Chrome already does 

https://www.nczonline.net/blog/2009/03/10/the-art-of-throwing-javascript-errors-part-2/