### PR TITLE
fix for scrollbar android issue

### DIFF
--- a/js/highstock.src.js
+++ b/js/highstock.src.js
@@ -21853,7 +21853,7 @@
 
                 // In iOS, a mousemove event with e.pageX === 0 is fired when holding the finger
                 // down in the center of the scrollbar. This should be ignored.
-                if (e.pageX !== 0) {
+                if (e.touches[0].pageX !== 0) {
 
                     e = chart.pointer.normalize(e);
                     chartX = e.chartX;


### PR DESCRIPTION
We are unable to drag the scrollbar on Android devices and I have identified this as the issue.

The pageX is not being calculated correctly on Android devices.
This occurs when using Highstocks with Cordova & Ionic in a hybrid web app.

I think it is better practise to obtain pageX from the touches array rather than directly from the event.